### PR TITLE
Added `struct Bar` with equally named attribute of different type.

### DIFF
--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,17 +9,21 @@ pub struct Foo {
     batz: i32
 }
 
+pub struct Bar {
+    batz: String,
+}
+
 #[test]
 fn simple_access() {
     #[derive(Default)]
-    struct Bar;
+    struct FooAttributeBar;
     #[derive(Default)]
-    struct Batz;
+    struct FooAttributeBatz;
 
     #[derive(Default)]
     struct FooAttributes {
-        bar: Bar,
-        batz: Batz
+        bar: FooAttributeBar,
+        batz: FooAttributeBatz
     }
 
     impl Attributes<FooAttributes> for Foo {
@@ -28,10 +32,10 @@ fn simple_access() {
         }
     }
 
-    impl Attr<Foo> for Bar {
+    impl Attr<Foo> for FooAttributeBar {
         type Output = String;
 
-        fn get<'a, >(&self, i: &'a Foo) -> &'a String {
+        fn get<'a, >(&self, i: &'a Foo) -> &'a Self::Output {
             &i.bar
         }
 
@@ -40,16 +44,16 @@ fn simple_access() {
         }
     }
 
-    impl AttrMut<Foo> for Bar {
-        fn get_mut<'a, >(&self, i: &'a mut Foo) -> &'a mut String {
+    impl AttrMut<Foo> for FooAttributeBar {
+        fn get_mut<'a, >(&self, i: &'a mut Foo) -> &'a mut Self::Output {
             &mut i.bar
         }
     }
 
-    impl Attr<Foo> for Batz {
+    impl Attr<Foo> for FooAttributeBatz {
         type Output = i32;
 
-        fn get<'a, >(&self, i: &'a Foo) -> &'a i32 {
+        fn get<'a, >(&self, i: &'a Foo) -> &'a Self::Output {
             &i.batz
         }
 
@@ -58,14 +62,43 @@ fn simple_access() {
         }
     }
 
-    impl AttrMut<Foo> for Batz {
-        fn get_mut<'a, >(&self, i: &'a mut Foo) -> &'a mut i32 {
+    impl AttrMut<Foo> for FooAttributeBatz {
+        fn get_mut<'a, >(&self, i: &'a mut Foo) -> &'a mut Self::Output {
             &mut i.batz
+        }
+    }
+
+    #[derive(Default)]
+    struct BarAttributeBatz;
+
+    #[derive(Default)]
+    struct BarAttributes {
+        batz: BarAttributeBatz,
+    }
+
+    impl Attributes<BarAttributes> for Bar {
+        fn attrs() -> BarAttributes {
+            BarAttributes::default()
+        }
+    }
+
+    impl Attr<Bar> for BarAttributeBatz {
+        type Output = String;
+
+        fn get<'a, >(&self, i: &'a Bar) -> &'a Self::Output {
+            &i.batz
+        }
+
+        fn name(&self) -> &'static str {
+            "batz"
         }
     }
 
     let f = Foo { bar: "foobar".into(), batz: 20 };
     Foo::attrs().bar.get(&f);
     Foo::attrs().batz.get(&f);
+
+    let f = Bar { batz: "foobar".into() };
+    Bar::attrs().batz.get(&f);
 
 }


### PR DESCRIPTION
Avoiding collisions via prefixed helper types.
Thanks to use of `trait Attributes` these don't leak into the actual user code.
